### PR TITLE
Whitespaces after a colon gets doubled

### DIFF
--- a/RestServer.php
+++ b/RestServer.php
@@ -34,6 +34,7 @@ class RestFormat
 	const AMF = 'applicaton/x-amf';
 	const JSON = 'application/json';
 	const JSONP = 'application/json-p';
+        const XML = 'text/xml';
 	static public $formats = array(
 		'plain' => RestFormat::PLAIN,
 		'txt' => RestFormat::PLAIN,
@@ -41,6 +42,7 @@ class RestFormat
 		'amf' => RestFormat::AMF,
 		'json' => RestFormat::JSON,
 		'jsonp' => RestFormat::JSONP,
+                'xml' => RestFormat::XML,
 	);
 }
 
@@ -373,6 +375,8 @@ class RestServer
 			$format = RestFormat::JSON;
 		} elseif (in_array(RestFormat::JSONP, $accept)) {
 			$format = RestFormat::JSONP;
+		} elseif (in_array(RestFormat::XML, $accept)) {
+			$format = RestFormat::XML;
 		}
 		return $format;
 	}
@@ -387,6 +391,14 @@ class RestServer
 			$stream = new Zend_Amf_Parse_InputStream($data);
 			$deserializer = new Zend_Amf_Parse_Amf3_Deserializer($stream);
 			$data = $deserializer->readTypeMarker();
+		} elseif ($this->format == RestFormat::XML) {
+                        require_once('XML/Serializer.php');
+                        $unserializer = &new XML_Unserializer();
+                        $unserializer->setOption('parseAttributes', true);
+                        $unserializer->setOption('decodeFunction', 'strtolower');
+                        
+                        $result = $unserializer->unserialize($xml);
+                        $data = $unserializer->getUnserializedData();
 		} else { // JSON, JSONP
 			$data = json_decode($data);
 		}
@@ -408,6 +420,17 @@ class RestServer
 			$serializer = new Zend_Amf_Parse_Amf3_Serializer($stream);
 			$serializer->writeTypeMarker($data);
 			$data = $stream->getStream();
+                } elseif ($this->format == RestFormat::XML) {
+                        require_once('XML/Serializer.php');
+                        $options = array(
+                                XML_SERIALIZER_OPTION_INDENT               => '  ',
+                                XML_SERIALIZER_OPTION_LINEBREAKS           => "\n",
+                                XML_SERIALIZER_OPTION_SCALAR_AS_ATTRIBUTES => true,
+                                XML_SERIALIZER_OPTION_RETURN_RESULT        => true,
+                                XML_SERIALIZER_OPTION_DEFAULT_TAG          => "item"
+                                         );
+                        $serializer = &new XML_Serializer($options);
+                        $data = $serializer->serialize($data);
 		} else {
 			if (is_object($data) && method_exists($data, '__keepOut')) {
 				$data = clone $data;


### PR DESCRIPTION
If a method returns a string like this "not yet implemented: will be there on 12/24/2011" the associated REST method returns: "not yet implemented:  will be there on 12/24/2011" (mind the two whitespaces after the :  — I expected only one whitespace there).

I haven't fixed this issue in my repo but I'll be doing it in the next days… 
