### PR TITLE
Just a little change

### DIFF
--- a/RestServer.php
+++ b/RestServer.php
@@ -137,13 +137,14 @@ class RestServer
 				}
 				
 				$result = call_user_func_array(array($obj, $method), $params);
+				
+				if ($result !== null) {
+					$this->sendData($result);
+				}
 			} catch (RestException $e) {
 				$this->handleError($e->getCode(), $e->getMessage());
-			}
-			
-			if ($result !== null) {
-				$this->sendData($result);
-			}
+			}			
+		
 		} else {
 			$this->handleError(404);
 		}


### PR DESCRIPTION
We've been using the RestServer on some internal tools and one problem I've found it requests getting cached and later being used to pull an object instance that no longer exists.

In this case I wanted the system to throw a 404 no found error and the way to do this seemed to be to throw a RestException(404). The problem is this then causes issues as the code outside the try block is trying to use result which doesn't exist.

So I moved the sendData call into the try block and it's all working as expected. 
