### PR TITLE
prepared for packagist / implemented usage of composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea
+composer.lock
+vendor

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ git clone https://github.com/jacwright/RestServer .
 composer install
 ```
 
-## By [Packagist](https://packagist.org/packages/jacwright/RestServer]
+## By [Packagist](https://packagist.org/packages/jacwright/RestServer)
 
 ```
 cd <your project>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 A PHP REST server for providing a very light-weight REST API. Very easy to set up and get going. Independent from other libraries and frameworks. Supports HTTP authentication.
 
-Initial Documentation from http://jacwright.com/250/simple-rest-server-in-php-supports-json-amf/
-
 ## Simple REST server in PHP
 
 After building a couple of RESTful services using the [Zend Framework](http://framework.zend.com/), I decided to create a dead simple REST server that allowed me to skip all the features I didn’t need as well as a **tons of classes** that came with Zend Framework MVC. There are still useful features to add (XML support for example), but overall I’m quite happy with what I’ve come up with.
@@ -124,32 +122,6 @@ $server->handle();
 That’s it. You can add as many classes as you like. If there are conflicts, classes added later will overwrite duplicate URL mappings that were added earlier. And the second parameter in addClass can be a base URL which will be prepended to URL mappings in the given class, allowing you to be more modular.
 
 You can [view the RestServer class](https://github.com/jacwright/RestServer/blob/master/RestServer.php), copy it and use it for your own purposes. It is under the MIT license. Features to be added include XML support and HTTP Authentication support. If you make this class better please share your updates with everyone by leaving a comment. I will try and keep this class updated with new features as they are shared. I hope you enjoy!
-
-I changed the title of this post to remove the AMF portion but was asked to cover it, so I will quickly talk about the AMF support. RestServer supports the AMF format in addition to the JSON format. This is a binary format used by Adobe Flash in their remoting services, but because their remoting services are not RESTful, you can’t use classes such as RemoteObject with REST.
-
-In order to use the AMF format with this service, you’ll need to have the Zend Framework in your classpath so that the classes to serialize and deserialize AMF are present (e.g. Zend/Amf/Parse/Amf3/Serializer.php). Then you’re ready so server up AMF. The way you consume AMF in Flash is using URLLoader or URLStream to load the data and ByteArray to convert it into an object. To tell the server you want AMF rather than JSON your URLRequest object will need to add an Accept header of “application/x-amf”. Below I will show you how this could be done.
-
-```php
-public function getUser():void
-{
-    var loader:URLLoader = new URLLoader();
-    loader.dataFormat = URLLoaderDataFormat.BINARY;
-    var request:URLRequest = new URLRequest("http://www.example.com/users/current");
-    request.requestHeaders.push(new URLRequestHeader("Accept", "application/x-amf"));
-    loader.addEventListener(Event.COMPLETE, onComplete);
-    loader.load(request);
-}
-
-private function onComplete(event:Event):void
-{
-    var loader:URLLoader = event.target as URLLoader;
-    var byteArray:ByteArray = loader.data as ByteArray;
-    var user:Object = byteArray.readObject();
-    // do something with the user
-}
-```
-
-You can even make your PHP objects cast into their actionscript equivalents using the $_explicitType property or getASClassName method in PHP as defined in the [documentation](http://framework.zend.com/manual/en/zend.amf.server.html#zend.amf.server.typedobjects) and by using registerAlias in Flash.
 
 Good luck and let me know if you end up using it!
 

--- a/README.md
+++ b/README.md
@@ -204,3 +204,22 @@ You may provide errors to your API users easily by throwing an excetion with the
 
 
 You have control over how your REST service handles errors. You can add an error controller using `$server->addErrorClass('ErrorController');`. This controller can define methods named `handle401` or `handle404` to add your own custom error handling logic.
+
+# Installation
+
+## By [Hand](jacwright/RestServer)
+
+```
+cd <your project>
+mkdir -p vendor/jacwright/RestServer
+cd vendor/jacwright/RestServer
+git clone https://github.com/jacwright/RestServer .
+composer install
+```
+
+## By [Packagist](https://packagist.org/packages/jacwright/RestServer]
+
+```
+cd <your project>
+composer require 'jacwright/RestServer:dev-master'
+```

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,26 @@
+{
+    "name": "jacwright/RestServer",
+    "type": "library",
+    "description": "php rest server for very light-weight REST APIs",
+    "keywords": ["php", "rest", "rest-server", "light-weight", "http", "json", "MIT"],
+    "homepage": "https://github.com/jacwright/RestServer",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Jacob Wright",
+            "email": "jacwright@gmail.com",
+            "homepage": "http://jacwright.com",
+            "role": "Developer"
+        }
+    ],
+    "minimum-stability": "dev",
+    "require": {
+        "php": ">=5.3.3",
+        "zf1/zend-amf": "1.12.11"
+    },
+    "autoload": {
+        "psr-0": {
+            "Jacwright\\RestServer": "source/"
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.3",
-        "zf1/zend-amf": "1.12.11"
+        "php": ">=5.3.3"
     },
     "autoload": {
         "psr-0": {

--- a/example/TestController.php
+++ b/example/TestController.php
@@ -21,7 +21,7 @@ class TestController
     public function login()
     {
         $username = $_POST['username'];
-        $password = $_POST['password'];
+        $password = $_POST['password']; //@todo remove since it is not needed anywhere
         return array("success" => "Logged in " . $username);
     }
 

--- a/example/index.php
+++ b/example/index.php
@@ -1,8 +1,8 @@
 <?php
 
-require '../RestServer.php';
+require __DIR__ . '/../vendor/autoload.php';
 require 'TestController.php';
 
-$server = new RestServer('debug');
+$server = new \Jacwright\RestServer\RestServer('debug');
 $server->addClass('TestController');
 $server->handle();

--- a/source/Jacwright/RestServer/RestException.php
+++ b/source/Jacwright/RestServer/RestException.php
@@ -1,0 +1,36 @@
+<?php
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2009 Jacob Wright
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+namespace Jacwright\RestServer;
+
+use Exception;
+
+class RestException extends Exception
+{
+    public function __construct($code, $message = null)
+    {
+        parent::__construct($message, $code);
+    }
+}

--- a/source/Jacwright/RestServer/RestFormat.php
+++ b/source/Jacwright/RestServer/RestFormat.php
@@ -1,0 +1,48 @@
+<?php
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2009 Jacob Wright
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+namespace Jacwright\RestServer;
+
+/**
+ * Constants used in RestServer Class.
+ */
+class RestFormat
+{
+	const PLAIN = 'text/plain';
+	const HTML  = 'text/html';
+	const AMF   = 'applicaton/x-amf';
+	const JSON  = 'application/json';
+	const XML   = 'application/xml';
+
+    /** @var array */
+	static public $formats = array(
+		'plain' => RestFormat::PLAIN,
+		'txt'   => RestFormat::PLAIN,
+		'html'  => RestFormat::HTML,
+		'amf'   => RestFormat::AMF,
+		'json'  => RestFormat::JSON,
+		'xml'   => RestFormat::XML,
+	);
+}

--- a/source/Jacwright/RestServer/RestFormat.php
+++ b/source/Jacwright/RestServer/RestFormat.php
@@ -32,7 +32,6 @@ class RestFormat
 {
 	const PLAIN = 'text/plain';
 	const HTML  = 'text/html';
-	const AMF   = 'applicaton/x-amf';
 	const JSON  = 'application/json';
 	const XML   = 'application/xml';
 
@@ -41,7 +40,6 @@ class RestFormat
 		'plain' => RestFormat::PLAIN,
 		'txt'   => RestFormat::PLAIN,
 		'html'  => RestFormat::HTML,
-		'amf'   => RestFormat::AMF,
 		'json'  => RestFormat::JSON,
 		'xml'   => RestFormat::XML,
 	);

--- a/source/Jacwright/RestServer/RestServer.php
+++ b/source/Jacwright/RestServer/RestServer.php
@@ -23,26 +23,17 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-/**
- * Constants used in RestServer Class.
- */
-class RestFormat
-{
+namespace Jacwright\RestServer;
 
-	const PLAIN = 'text/plain';
-	const HTML = 'text/html';
-	const AMF = 'applicaton/x-amf';
-	const JSON = 'application/json';
-	const XML = 'application/xml';
-	static public $formats = array(
-		'plain' => RestFormat::PLAIN,
-		'txt' => RestFormat::PLAIN,
-		'html' => RestFormat::HTML,
-		'amf' => RestFormat::AMF,
-		'json' => RestFormat::JSON,
-		'xml'  => RestFormat::XML,
-	);
-}
+use Exception;
+use ReflectionClass;
+use ReflectionObject;
+use ReflectionMethod;
+use DOMDocument;
+use Zend_Amf_Parse_Amf3_Deserializer;
+use Zend_Amf_Parse_Amf3_Serializer;
+use Zend_Amf_Parse_InputStream;
+use Zend_Amf_Parse_OutputStream;
 
 /**
  * Description of RestServer
@@ -51,6 +42,7 @@ class RestFormat
  */
 class RestServer
 {
+    //@todo add type hint
 	public $url;
 	public $method;
 	public $params;
@@ -135,7 +127,7 @@ class RestServer
 				
 				if (!$noAuth && method_exists($obj, 'authorize')) {
 					if (!$obj->authorize()) {
-						$this->sendData($this->unauthorized(true));
+						$this->sendData($this->unauthorized(true)); //@todo unauthorized returns void
 						exit;
 					}
 				}
@@ -247,7 +239,7 @@ class RestServer
 				if ($url == $this->url) {
 					if (isset($args['data'])) {
 						$params = array_fill(0, $args['data'] + 1, null);
-						$params[$args['data']] = $this->data;
+						$params[$args['data']] = $this->data;   //@todo data is not a property of this class
 						$call[2] = $params;
 					}
 					return $call;
@@ -296,7 +288,7 @@ class RestServer
 			$reflection = new ReflectionClass($class);
 		}
 		
-		$methods = $reflection->getMethods(ReflectionMethod::IS_PUBLIC);
+		$methods = $reflection->getMethods(ReflectionMethod::IS_PUBLIC);    //@todo $reflection might not be instantiated
 		
 		foreach ($methods as $method) {
 			$doc = $method->getDocComment();
@@ -384,11 +376,9 @@ class RestServer
 		$data = file_get_contents('php://input');
 		
 		if ($this->format == RestFormat::AMF) {
-			require_once 'Zend/Amf/Parse/InputStream.php';
-			require_once 'Zend/Amf/Parse/Amf3/Deserializer.php';
-			$stream = new Zend_Amf_Parse_InputStream($data);
-			$deserializer = new Zend_Amf_Parse_Amf3_Deserializer($stream);
-			$data = $deserializer->readTypeMarker();
+			$stream         = new Zend_Amf_Parse_InputStream($data);
+			$deserializer   = new Zend_Amf_Parse_Amf3_Deserializer($stream);
+			$data           = $deserializer->readTypeMarker();
 		} else {
 			$data = json_decode($data);
 		}
@@ -404,9 +394,7 @@ class RestServer
 		header('Content-Type: ' . $this->format);
 
 		if ($this->format == RestFormat::AMF) {
-			require_once 'Zend/Amf/Parse/OutputStream.php';
-			require_once 'Zend/Amf/Parse/Amf3/Serializer.php';
-			$stream = new Zend_Amf_Parse_OutputStream();
+			$stream     = new Zend_Amf_Parse_OutputStream();
 			$serializer = new Zend_Amf_Parse_Amf3_Serializer($stream);
 			$serializer->writeTypeMarker($data);
 			$data = $stream->getStream();}
@@ -419,7 +407,7 @@ class RestServer
 					unset($data->$prop);
 				}
 			}
-			$data = $this->xml_encode($data);
+			$data = $this->xml_encode($data);   //@todo method returns void
 			if ($data && $this->mode == 'debug') {
 				$data = $this->json_format($data);
 			}
@@ -446,7 +434,7 @@ class RestServer
 		header("{$_SERVER['SERVER_PROTOCOL']} $code");
 	}
 	
-	private function xml_encode($mixed, $domElement=null, $DOMDocument=null) {
+	private function xml_encode($mixed, $domElement=null, $DOMDocument=null) {  //@todo add type hint for $domElement and $DOMDocument
     if (is_null($DOMDocument)) {
         $DOMDocument =new DOMDocument;
         $DOMDocument->formatOutput = true;
@@ -541,6 +529,7 @@ class RestServer
 					if($c != $backslashed) {
 						$in_string = !$in_string;
 					}
+                    break;
 				default:
 					$new_json .= $char;
 					break;					
@@ -587,14 +576,4 @@ class RestServer
 		'501' => 'Not Implemented',
 		'503' => 'Service Unavailable'
 	);
-}
-
-class RestException extends Exception
-{
-	
-	public function __construct($code, $message = null)
-	{
-		parent::__construct($message, $code);
-	}
-	
 }

--- a/source/Jacwright/RestServer/RestServer.php
+++ b/source/Jacwright/RestServer/RestServer.php
@@ -30,10 +30,6 @@ use ReflectionClass;
 use ReflectionObject;
 use ReflectionMethod;
 use DOMDocument;
-use Zend_Amf_Parse_Amf3_Deserializer;
-use Zend_Amf_Parse_Amf3_Serializer;
-use Zend_Amf_Parse_InputStream;
-use Zend_Amf_Parse_OutputStream;
 
 /**
  * Description of RestServer
@@ -363,8 +359,6 @@ class RestServer
 		$override = isset($_GET['format']) ? $_GET['format'] : $override;
 		if (isset(RestFormat::$formats[$override])) {
 			$format = RestFormat::$formats[$override];
-		} elseif (in_array(RestFormat::AMF, $accept)) {
-			$format = RestFormat::AMF;
 		} elseif (in_array(RestFormat::JSON, $accept)) {
 			$format = RestFormat::JSON;
 		}
@@ -374,15 +368,8 @@ class RestServer
 	public function getData()
 	{
 		$data = file_get_contents('php://input');
-		
-		if ($this->format == RestFormat::AMF) {
-			$stream         = new Zend_Amf_Parse_InputStream($data);
-			$deserializer   = new Zend_Amf_Parse_Amf3_Deserializer($stream);
-			$data           = $deserializer->readTypeMarker();
-		} else {
-			$data = json_decode($data);
-		}
-		
+        $data = json_decode($data);
+
 		return $data;
 	}
 	
@@ -393,13 +380,7 @@ class RestServer
 		header("Expires: 0");
 		header('Content-Type: ' . $this->format);
 
-		if ($this->format == RestFormat::AMF) {
-			$stream     = new Zend_Amf_Parse_OutputStream();
-			$serializer = new Zend_Amf_Parse_Amf3_Serializer($stream);
-			$serializer->writeTypeMarker($data);
-			$data = $stream->getStream();}
-
-		elseif ($this->format == RestFormat::XML) {
+		if ($this->format == RestFormat::XML) {
 
 		if (is_object($data) && method_exists($data, '__keepOut')) {
 				$data = clone $data;


### PR DESCRIPTION
This pull request solves overwhelms [pull/18](https://github.com/jacwright/RestServer/pull/18).
All jacwright has to do is, to submit this repository to packagist.org after accepting this pull request.

I've added the dependency to "zf1/zend-amf": "1.12.11" since it is used in the code.
Furthermore, I've moved the three class definitions into separate files, added the namespace "Jacwright\RestServer", adapted the example and added todo's (in general, warnings/hints from my IDE).