### PR TITLE
Fix compatability with PHP5.3

### DIFF
--- a/source/Jacwright/RestServer/RestServer.php
+++ b/source/Jacwright/RestServer/RestServer.php
@@ -428,10 +428,14 @@ class RestServer
 				}
 			}
 			$options = 0;
-			if ($this->mode == 'debug') {
+			if ($this->mode == 'debug' && defined('JSON_PRETTY_PRINT')) {
 				$options = JSON_PRETTY_PRINT;
 			}
-			$options = $options | JSON_UNESCAPED_UNICODE;
+
+			if (defined('JSON_UNESCAPED_UNICODE')) {
+				$options = $options | JSON_UNESCAPED_UNICODE;
+			}
+
 			echo json_encode($data, $options);
 		}
 	}


### PR DESCRIPTION
The Following constants are only defined as of PHP5.4, and are assumed to be strings by the interpreter:
- JSON_PRETTY_PRINT
- JSON_UNESCAPED_UNICODE