### PR TITLE
#79 - Split out Authentication from RestServer

### DIFF
--- a/source/Jacwright/RestServer/Auth/HTTPAuthServer.php
+++ b/source/Jacwright/RestServer/Auth/HTTPAuthServer.php
@@ -1,0 +1,23 @@
+<?php
+namespace Jacwright\RestServer\Auth;
+
+class HTTPAuthServer implements \Jacwright\RestServer\AuthServer {
+	protected $realm;
+
+	public function __construct($realm = 'Rest Server') {
+		$this->realm = $realm;
+	}
+
+	public function isAuthorized($classObj) {
+		if (method_exists($classObj, 'authorize')) {
+			return $classObj->authorize();
+		}
+
+		return true;
+	}
+
+	public function unauthorized($classObj) {
+		header("WWW-Authenticate: Basic realm=\"$this->realm\"");
+		throw new \Jacwright\RestServer\RestException(401, "You are not authorized to access this resource.");
+	}
+}

--- a/source/Jacwright/RestServer/AuthServer.php
+++ b/source/Jacwright/RestServer/AuthServer.php
@@ -1,0 +1,26 @@
+<?php
+namespace Jacwright\RestServer;
+
+interface AuthServer {
+	/**
+	 * Indicates whether the client is authorized to access the resource.
+	 *
+	 * @param string $path     The requested path.
+	 * @param object $classObj An instance of the controller for the path.
+	 *
+	 * @return bool True if authorized, false if not.
+	 */
+	public function isAuthorized($classObj);
+
+	/**
+	 * Handles the case where the client is not authorized.
+	 * This method must either return data or throw a RestException.
+	 *
+	 * @param string $path The requested path.
+	 *
+	 * @return mixed The response to send to the client
+	 *
+	 * @throws RestException
+	 */
+	public function unauthorized($classObj);
+}


### PR DESCRIPTION
This allows users to define their own AuthServer handlers to support different authentication schemes. By default, an instance of HTTPAuthServer is registered for backwards compatibility.