### PR TITLE
Enable CORS and using parameters after ? in get command

### DIFF
--- a/source/Jacwright/RestServer/RestServer.php
+++ b/source/Jacwright/RestServer/RestServer.php
@@ -53,6 +53,7 @@ class RestServer {
 	public $authHandler = null;
 
 	public $useCors = false;
+	public $getParamAssoc;
 
 	protected $map = array();
 	protected $errorClasses = array();
@@ -379,6 +380,9 @@ class RestServer {
 	}
 
 	public function getPath() {
+		$getParameters = parse_url ($_SERVER['REQUEST_URI'], PHP_URL_QUERY);
+		parse_str($getParameters, $this->getParamAssoc);
+
 		$path = preg_replace('/\?.*$/', '', $_SERVER['REQUEST_URI']);
 
 		// remove root from path

--- a/source/Jacwright/RestServer/RestServer.php
+++ b/source/Jacwright/RestServer/RestServer.php
@@ -53,7 +53,6 @@ class RestServer {
 	public $authHandler = null;
 
 	public $useCors = false;
-	public $getParamAssoc;
 
 	protected $map = array();
 	protected $errorClasses = array();
@@ -116,9 +115,9 @@ class RestServer {
 
 		if (($this->useCors) && ($this->method == 'OPTIONS')) {
 			$this->corsHeaders();
-			exit;      
+			exit;
 		}
-		
+
 		if ($this->method == 'PUT' || $this->method == 'POST' || $this->method == 'PATCH') {
 			$this->data = $this->getData();
 		}
@@ -380,9 +379,6 @@ class RestServer {
 	}
 
 	public function getPath() {
-		$getParameters = parse_url ($_SERVER['REQUEST_URI'], PHP_URL_QUERY);
-		parse_str($getParameters, $this->getParamAssoc);
-
 		$path = preg_replace('/\?.*$/', '', $_SERVER['REQUEST_URI']);
 
 		// remove root from path
@@ -550,7 +546,7 @@ class RestServer {
 		}
 	}
 
-  private function corsHeaders() {
+	private function corsHeaders() {
 		header('Access-Control-Allow-Origin: *');
 		header('Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS');
 		header('Access-Control-Allow-Credential: true');

--- a/source/Jacwright/RestServer/RestServer.php
+++ b/source/Jacwright/RestServer/RestServer.php
@@ -52,6 +52,8 @@ class RestServer {
 	public $jsonAssoc = false;
 	public $authHandler = null;
 
+	public $useCors = false;
+
 	protected $map = array();
 	protected $errorClasses = array();
 	protected $cached;
@@ -111,6 +113,11 @@ class RestServer {
 		$this->method = $this->getMethod();
 		$this->format = $this->getFormat();
 
+		if (($this->useCors) && ($this->method == 'OPTIONS')) {
+			$this->corsHeaders();
+			exit;      
+		}
+		
 		if ($this->method == 'PUT' || $this->method == 'POST' || $this->method == 'PATCH') {
 			$this->data = $this->getData();
 		}
@@ -459,6 +466,10 @@ class RestServer {
 		header("Expires: 0");
 		header('Content-Type: ' . $this->format);
 
+		if ($this->useCors) {
+			$this->corsHeaders();
+		}
+		
 		if ($this->format == RestFormat::XML) {
 			if (is_object($data) && method_exists($data, '__keepOut')) {
 				$data = clone $data;
@@ -535,7 +546,13 @@ class RestServer {
 		}
 	}
 
-
+  private function corsHeaders() {
+		header('Access-Control-Allow-Origin: *');
+		header('Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS');
+		header('Access-Control-Allow-Credential: true');
+		header('Access-Control-Allow-Headers: X-Requested-With, content-type, access-control-allow-origin, access-control-allow-methods, access-control-allow-headers, Authorization');
+	}
+	
 	private $codes = array(
 		'100' => 'Continue',
 		'200' => 'OK',


### PR DESCRIPTION
1.	Enabling CORS (Cross-origin resource sharing)
By enabling field ($server->useCors = true) REST server can be used for Cross-origin resource sharing which is useful if you need to access a server from development computer

2.	Enable using GET parameters after ?
Sometime it is useful to have parameters in GET request (aka: http://something.com/users?active=1 – select only active users). In this case parameter active can be obtained with: $server->getParamAssoc['active'] 
