### PR TITLE
CORS: Support for multiple origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,23 @@ Inside your authentication method you can use PHP's [`getallheaders`](http://php
 
 RestServer is meant to be a simple mechanism to map your application into a REST API. The rest of the details are up to you.
 
+### Cross-origin resource sharing
+
+For security reasons, browsers restrict cross-origin HTTP or REST requests initiated from within scripts. So, a web application using REST APIs from browsers, could only make API requests to its own domain. To override this restriction `RestServer` can be configured to allow cros-orign requests, by including following code in REST index.php file.
+
+```php
+    /**
+     *
+     * include following lines after $server = new RestServer($mode); 
+     */
+     $server->useCors = true;
+     $server->allowedOrigin = 'http://example.com';
+     // or use array of multiple origins
+     $server->allowedOrigin = array('http://example.com', 'https://example.com');
+     // or a wildcard
+     $server->allowedOrigin = '*';
+```
+
 ### Throwing and Handling Errors
 
 You may provide errors to your API users easily by throwing an excetion with the class `RestException`. Example:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ class TestController
         $user = User::saveUser($data); // saving the user to the database
         return $user; // returning the updated or newly created user object
     }
+
+    /**
+     * Gets user list
+     *
+     * @url GET /users
+     */
+    public function listUsers($query)
+    {
+        $users = array('Andra Combes', 'Valerie Shirkey', 'Manda Douse', 'Nobuko Fisch', 'Roger Hevey');
+        if (isset($query['search'])) {
+          $users = preg_grep("/$query[search]/i", $users);
+        }
+        return $users; // serializes object into JSON
+    }
 }
 ```
 
@@ -90,7 +104,7 @@ Next we have our `getUser` method (you’ll notice that it doesn’t really matt
 
 One last thing to note in `getUser` is that this method simply returns a `User` object. This gets serialized into JSON (or potentially XML) and printed out for consumption by the application.
 
-Finally we get to `saveUser`. You see here we have multiple URL mappings again. This time they also have different HTTP methods (POST and PUT) for creating and updating a user. The new thing here is the `$data` variable. This is a special keyword parameter that will contain the value of whatever was POSTed or PUT to the server. This is different than your regular web POST in that it doesn’t need to only be name-value pairs, but can be as robust as JSON, sending complex objects. For example, the body of a regular web POST, let’s say the login request, might look like this:
+Next we have to `saveUser`. You see here we have multiple URL mappings again. This time they also have different HTTP methods (POST and PUT) for creating and updating a user. The new thing here is the `$data` variable. This is a special keyword parameter that will contain the value of whatever was POSTed or PUT to the server. This is different than your regular web POST in that it doesn’t need to only be name-value pairs, but can be as robust as JSON, sending complex objects. For example, the body of a regular web POST, let’s say the login request, might look like this:
 
 `username=bob&password=supersecretpassw0rd`
 
@@ -101,6 +115,8 @@ but POSTing a new user object for our saveUser method could look like this:
 ```
 
 So you’re able to allow POSTing JSON in addition to regular web style POSTs.
+
+Finally we get to `listUsers` method. It is simple as `test` method. but `$query` parameter is the new. This special parameter can be used to read query string. and hold query string parameters as associated array. for example if client request this API with url `/users?search=Manda` then `$query` parameter will hold `[search => Manada]`.
 
 I call these classes that handle the requests `Controllers`. And they can be completely self-contained with their URL mappings, database configs, etc. so that you could drop them into other RestServer services without any hassle.
 

--- a/example/TestController.php
+++ b/example/TestController.php
@@ -68,7 +68,7 @@ class TestController
     {
         $users = array('Andra Combes', 'Valerie Shirkey', 'Manda Douse', 'Nobuko Fisch', 'Roger Hevey');
         if (isset($query['search'])) {
-          $users = preg_grep("/$query[search]/i", $users);
+          $users = preg_grep("/{$query[search]}/i", $users);
         }
         return $users; // serializes object into JSON
     }

--- a/example/TestController.php
+++ b/example/TestController.php
@@ -60,6 +60,20 @@ class TestController
     }
 
     /**
+     * Gets user list
+     *
+     * @url GET /users
+     */
+    public function listUsers($query)
+    {
+        $users = array('Andra Combes', 'Valerie Shirkey', 'Manda Douse', 'Nobuko Fisch', 'Roger Hevey');
+        if (isset($query['search'])) {
+          $users = preg_grep("/$query[search]/i", $users);
+        }
+        return $users; // serializes object into JSON
+    }
+
+    /**
      * Get Charts
      * 
      * @url GET /charts

--- a/source/Jacwright/RestServer/RestServer.php
+++ b/source/Jacwright/RestServer/RestServer.php
@@ -390,10 +390,7 @@ class RestServer {
 
 	public function getPath() {
 		//@todo should only work with GET method
-		$getParameters = parse_url ($_SERVER['REQUEST_URI'], PHP_URL_QUERY);
-		if (!empty($getParameters)) {
-			parse_str($getParameters, $this->query);
-		}
+		$this->query = $_GET;
 
 		$path = preg_replace('/\?.*$/', '', $_SERVER['REQUEST_URI']);
 

--- a/source/Jacwright/RestServer/RestServer.php
+++ b/source/Jacwright/RestServer/RestServer.php
@@ -57,8 +57,8 @@ class RestServer {
 	public $useCors = false;
 	public $allowedOrigin = '*';
 
-  protected $data = null;   // special parameter for post data
-  protected $query = null;  // special parameter for query string
+	protected $data = null;   // special parameter for post data
+	protected $query = null;  // special parameter for query string
 	protected $map = array();
 	protected $errorClasses = array();
 	protected $cached;

--- a/source/Jacwright/RestServer/RestServer.php
+++ b/source/Jacwright/RestServer/RestServer.php
@@ -53,6 +53,7 @@ class RestServer {
 	public $authHandler = null;
 
 	public $useCors = false;
+	public $allowedOrigin = '*';
 
 	protected $map = array();
 	protected $errorClasses = array();
@@ -547,7 +548,13 @@ class RestServer {
 	}
 
 	private function corsHeaders() {
-		header('Access-Control-Allow-Origin: *');
+		$allowedOrigin = (array)$this->allowedOrigin; // to support multiple origins we have to treat origins as array
+		if (in_array('*', $allowedOrigin) || in_array($_SERVER['HTTP_ORIGIN'], $allowedOrigin)) {
+			$allowedOrigin = array($_SERVER['HTTP_ORIGIN']); // array ; if there is a match then only one is enough
+		}
+		foreach($allowedOrigin as $allowed_origin) { // to support multiple origins
+			header("Access-Control-Allow-Origin: $allowed_origin");
+		}
 		header('Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS');
 		header('Access-Control-Allow-Credential: true');
 		header('Access-Control-Allow-Headers: X-Requested-With, content-type, access-control-allow-origin, access-control-allow-methods, access-control-allow-headers, Authorization');

--- a/source/Jacwright/RestServer/RestServer.php
+++ b/source/Jacwright/RestServer/RestServer.php
@@ -57,6 +57,8 @@ class RestServer {
 	public $useCors = false;
 	public $allowedOrigin = '*';
 
+  protected $data = null;   // special parameter for post data
+  protected $query = null;  // special parameter for query string
 	protected $map = array();
 	protected $errorClasses = array();
 	protected $cached;
@@ -288,14 +290,14 @@ class RestServer {
 
 			if (!strstr($url, '$')) {
 				if ($url == $this->url) {
-				  $params = array();
+					$params = array();
 					if (isset($args['data'])) {
 						$params += array_fill(0, $args['data'] + 1, null);
-						$params[$args['data']] = isset($this->data) ? $this->data : null;   //@todo data is not a property of this class
+						$params[$args['data']] = $this->data;
 					}
 					if (isset($args['query'])) {
 						$params += array_fill(0, $args['query'] + 1, null);
-						$params[$args['query']] = isset($this->query) ? $this->query : null;   //@todo query is not a property of this class
+						$params[$args['query']] = $this->query;
 					}
 					$call[2] = $params;
 					return $call;


### PR DESCRIPTION
Access-Control-Allow-Origin: '*'
Above wildcard origin is dangerous and modern browsers also restrict it when using with authentication.

> Cannot use wildcard in Access-Control-Allow-Origin when credentials flag is true.

This pull request address this issue by allowing multiple origins! and it prepare its `Access-Control-Allow-Origin` response dynamically with correct origin, when it found a matching origin in request.
