### PR TITLE
auto empty response

### DIFF
--- a/source/Jacwright/RestServer/RestServer.php
+++ b/source/Jacwright/RestServer/RestServer.php
@@ -151,9 +151,7 @@ class RestServer {
 				} else {
 					$result = call_user_func_array(array($obj, $method), $params);
 
-					if ($result !== null) {
-						$this->sendData($result);
-					}
+					$this->sendData($result);
 				}
 			} catch (RestException $e) {
 				$this->handleError($e->getCode(), $e->getMessage());
@@ -483,7 +481,9 @@ class RestServer {
 			$this->corsHeaders();
 		}
 
-		if ($this->format == RestFormat::XML) {
+		if ($data === null) {
+			$this->setStatus(204);
+		} else if ($this->format == RestFormat::XML) {
 			if (is_object($data) && method_exists($data, '__keepOut')) {
 				$data = clone $data;
 				foreach ($data->__keepOut() as $prop) {


### PR DESCRIPTION
The current behavior when you do not return a value from your controller method is that an empty 200 response without CORS header is returned to the client.

This patch adds handling of empty responses by adding CORS header if configured and sets the HTTP status code to the appropriate 204 – No Content.