### PR TITLE
Configurable Default Format

### DIFF
--- a/source/Jacwright/RestServer/RestServer.php
+++ b/source/Jacwright/RestServer/RestServer.php
@@ -57,6 +57,7 @@ class RestServer {
 	public $useCors = false;
 	public $allowedOrigin = '*';
 
+	protected $defaultFormat = RestFormat::PLAIN;
 	protected $data = null;   // special parameter for post data
 	protected $query = null;  // special parameter for query string
 	protected $map = array();
@@ -67,8 +68,10 @@ class RestServer {
 	 * The constructor.
 	 *
 	 * @param string $mode The mode, either debug or production
+	 * @param string $defaultFormat
 	 */
-	public function  __construct($mode = 'debug') {
+	public function  __construct($mode = 'debug', $defaultFormat = RestFormat::PLAIN) {
+		$this->defaultFormat = $defaultFormat;
 		$this->mode = $mode;
 
 		// Set the root
@@ -169,6 +172,17 @@ class RestServer {
 
 	public function setJsonAssoc($value) {
 		$this->jsonAssoc = ($value === true);
+	}
+
+	/**
+	 * @param string $defaultFormat
+	 *
+	 * @return RestServer
+	 */
+	public function setDefaultFormat( $defaultFormat ) {
+		$this->defaultFormat = $defaultFormat;
+
+		return $this;
 	}
 
 	public function addClass($class, $basePath = '') {
@@ -433,7 +447,7 @@ class RestServer {
 	}
 
 	public function getFormat() {
-		$format = RestFormat::PLAIN;
+		$format = $this->defaultFormat;
 		$accept_mod = null;
 
 		if (isset($_SERVER["HTTP_ACCEPT"])) {


### PR DESCRIPTION
This commit allows for the default response format to be changed. This will let developers set the default format for their API without the need for additional query parameters.