### PR TITLE
fixed invalid property access on getallheaders

### DIFF
--- a/source/Jacwright/RestServer/RestServer.php
+++ b/source/Jacwright/RestServer/RestServer.php
@@ -128,7 +128,7 @@ class RestServer {
 		}
 
 		//preflight requests response
-		if ($this->method == 'OPTIONS' && getallheaders()->Access-Control-Request-Headers) {
+		if ($this->method == 'OPTIONS' && getallheaders()['Access-Control-Request-Headers']) {
 			$this->sendData($this->options());
 		}
 


### PR DESCRIPTION
- changed object access to array access because the return type of getallheaders is an array...

...otherwise preflight requests will always fail.

**Comparision:**
`getallheaders()->Access-Control-Request-Headers`  -> `0` -> `false` 
`getallheaders()['Access-Control-Request-Headers'] ` ->  `<any string value>` -> `true` 


i dont know why this got changed in commit ebe90e5f0accd56b630b3b18bacb5212155798e4
But it must be invalid regarding the php docs ( https://www.php.net/manual/de/function.getallheaders ) 


