### PR TITLE
Extend RestException to also accept error object

### DIFF
--- a/source/Jacwright/RestServer/RestException.php
+++ b/source/Jacwright/RestServer/RestException.php
@@ -28,7 +28,15 @@ namespace Jacwright\RestServer;
 use Exception;
 
 class RestException extends Exception {
-	public function __construct($code, $message = null) {
+	private $_data = '';
+
+	public function __construct($code, $message = null, $data = null) {
+		$this->_data = $data;
 		parent::__construct($message, $code);
+	}
+
+	public function getData()
+	{
+			return $this->_data;
 	}
 }

--- a/source/Jacwright/RestServer/RestServer.php
+++ b/source/Jacwright/RestServer/RestServer.php
@@ -155,7 +155,7 @@ class RestServer {
 					}
 				}
 			} catch (RestException $e) {
-				$this->handleError($e->getCode(), $e->getMessage());
+				$this->handleError($e->getCode(), $e->getMessage(), $e->getData());
 			}
 		} else {
 			$this->handleError(404);
@@ -196,7 +196,7 @@ class RestServer {
 		$this->errorClasses[] = $class;
 	}
 
-	public function handleError($statusCode, $errorMessage = null) {
+	public function handleError($statusCode, $errorMessage = null, $data = null) {
 		$method = "handle$statusCode";
 
 		foreach ($this->errorClasses as $class) {
@@ -220,7 +220,7 @@ class RestServer {
 		}
 
 		$this->setStatus($statusCode);
-		$this->sendData(array('error' => array('code' => $statusCode, 'message' => $errorMessage)));
+		$this->sendData(array('error' => array('code' => $statusCode, 'message' => $errorMessage, 'data' => $data)));
 	}
 
 	protected function instantiateClass($obj) {


### PR DESCRIPTION
This enables the developer to return additional data to user.
So in case of an error in REST function, the error can be additionaly explained

**in code:**

```php
throw new RestException(400, "Missing properties", ["severity" => "high", "missing" => ['date', 'name']]);
```

**in REST response**

```json
{
    "error": {
        "code": 400,
        "message": "Missing properties",
        "data": {
            "severity": "high",
            "missing": [
                "date",
                "name"
            ]
        }
    }
}
```